### PR TITLE
Add pagination to the parts listing

### DIFF
--- a/partuniverse/partsmanagement/views.py
+++ b/partuniverse/partsmanagement/views.py
@@ -198,7 +198,7 @@ class CategoryUpdateView(UpdateView):
 class PartsList(ListView):
     model = Part
     template_name = 'pmgmt/part/list.html'
-    paginate_by = 10
+    paginate_by = 25
 
     @property
     def search(self):

--- a/partuniverse/partsmanagement/views.py
+++ b/partuniverse/partsmanagement/views.py
@@ -198,6 +198,7 @@ class CategoryUpdateView(UpdateView):
 class PartsList(ListView):
     model = Part
     template_name = 'pmgmt/part/list.html'
+    paginate_by = 10
 
     @property
     def search(self):

--- a/partuniverse/templates/pmgmt/part/list.html
+++ b/partuniverse/templates/pmgmt/part/list.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load staticfiles %}
+{% load debug_filters %}
 
 {% block breadcrumbs %}
 <a href="{% url "part_list" %}" class="active section">{% trans "Parts" %}</a>
@@ -98,6 +99,16 @@
     {% endfor %}
   </tbody>
 </table>
+
+{% if is_paginated %}
+<div class="ui fluid pagination menu">
+  {% for number in page_obj.paginator.page_range %}
+  <a class="{% if number == page_obj.number %}active {% endif %}item" href="{% url "part_list" %}?page={{ number }}{% if view.search %}&amp;search={{ view.search }}{% endif %}">
+    {{ number }}
+  </a>
+  {% endfor %}
+</div>
+{% endif %}
 
 {% else %}
 <p>{% trans "No data available at the moment." %}</p>

--- a/partuniverse/templates/pmgmt/part/list.html
+++ b/partuniverse/templates/pmgmt/part/list.html
@@ -2,7 +2,6 @@
 
 {% load i18n %}
 {% load staticfiles %}
-{% load debug_filters %}
 
 {% block breadcrumbs %}
 <a href="{% url "part_list" %}" class="active section">{% trans "Parts" %}</a>


### PR DESCRIPTION
Fixes #161 

Is a bit rudimentary, because it will blow up if you have more than ~ 6 Pages, but works for now. Also 10 Items per page is open for discussion.