### PR TITLE
Slightly lower left + right padding for menu items

### DIFF
--- a/partuniverse/static/all/custom/all.css
+++ b/partuniverse/static/all/custom/all.css
@@ -3,6 +3,10 @@ main.main.container {
   min-height: calc(100% - 108px);
 }
 
+.ui.menu .item {
+  padding: 0.7em 0.8em;
+}
+
 .ui.footer.segment {
   margin: 2em 0em 0em;
   padding: 2em 0em;


### PR DESCRIPTION
The proposed update slightly reduces the padding left and right of items in the header menu (from 1.1em to 0.8em). This enables to show all buttons on lower resolved screens (especially smart phones!), otherwise the "login"-button would be partially hidden.

Alternatively we could use something like the following or use a proper responsive menu:

@media screen and (max-width: 1200px) {
.ui.menu .item {
  padding: 0.7em 0.4em;
}
}

The proposed change seems to be good enough for me however. And it doesn't restrict the usability on higher resolved screens.