### PR TITLE
Added newlines to help texts and fixed some typos

### DIFF
--- a/partuniverse/locale/de/LC_MESSAGES/django.po
+++ b/partuniverse/locale/de/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-09 08:37+0000\n"
+"POT-Creation-Date: 2022-08-20 22:03+0000\n"
 "PO-Revision-Date: 2014-11-21 19:35+0100\n"
 "Last-Translator: Frank Lanitz <frank@frank.uvena.de>\n"
 "Language: \n"
@@ -26,259 +26,264 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: partsmanagement/exceptions.py:14
+#: partsmanagement/exceptions.py:16
 #, python-format
 msgid "An fatal error has been occurred: %s"
 msgstr "Ein gravierender Fehler ist aufgetreten: %s"
 
-#: partsmanagement/exceptions.py:23
+#: partsmanagement/exceptions.py:27
 #, python-format
 msgid "Exception: Parts cannot be combined: %s"
 msgstr "Fehler: Die Teile (%s) können nicht kombiniert werden"
 
-#: partsmanagement/exceptions.py:32
+#: partsmanagement/exceptions.py:37
 #, python-format
 msgid "Circle detected: %s"
 msgstr "Es wurde ein Kreis entdeckt: %s"
 
-#: partsmanagement/exceptions.py:55
+#: partsmanagement/exceptions.py:63
 #, python-format
 msgid "Storage Items are idendical: %s"
 msgstr "Die Einlagerungen sind identisch: %s"
 
-#: partsmanagement/exceptions.py:65
+#: partsmanagement/exceptions.py:74
 #, python-format
 msgid "Cannot revert Transaction: %s"
 msgstr "Kann die Transatkion nicht zurück rollen: %s"
 
-#: partsmanagement/forms.py:18
+#: partsmanagement/forms.py:17
 msgid "Parts now inside storage"
 msgstr "Teile innerhalb des Lagers"
 
-#: partsmanagement/forms.py:21
-msgid "The amount of currently inside storage place."
-msgstr "Die Menge, die sich aktuell am Lagerplatz befindet."
+#: partsmanagement/forms.py:20
+msgid "The amount of currently inside storage place.<br/><br/>"
+msgstr "Die Menge, die sich aktuell am Lagerplatz befindet.<br/><br/>"
 
-#: partsmanagement/forms.py:26 partsmanagement/forms.py:37
-#: partsmanagement/models.py:65 partsmanagement/models.py:143
-#: partsmanagement/models.py:326 partsmanagement/models.py:409
+#: partsmanagement/forms.py:25 partsmanagement/forms.py:35
+#: partsmanagement/models.py:61 partsmanagement/models.py:142
+#: partsmanagement/models.py:327 partsmanagement/models.py:416
 #: templates/pmgmt/category/detail.html:27 templates/pmgmt/part/detail.html:73
 #: templates/pmgmt/storage/detail.html:35
 #: templates/pmgmt/storagetype/detail.html:37
 msgid "Description"
 msgstr "Beschreibung"
 
-#: partsmanagement/forms.py:29 partsmanagement/forms.py:40
+#: partsmanagement/forms.py:27 partsmanagement/forms.py:37
 msgid "Difference"
 msgstr "Unterschied"
 
-#: partsmanagement/forms.py:32
+#: partsmanagement/forms.py:30
 msgid "The amount of items taken/put to storage."
 msgstr "Die Menge die ein- bzw. ausgelagert wurde."
 
-#: partsmanagement/forms.py:44
-msgid "The amount of items taken/put to storage. Positiv values only."
-msgstr "Die Menge die ein- bzw. ausgelagert wurde. Nur positive Werte."
+#: partsmanagement/forms.py:42
+msgid ""
+"The amount of items taken/put to storage. Positive values only.<br/><br/>"
+msgstr ""
+"Die Menge die ein- bzw. ausgelagert wurde. Nur positive Werte.<br/><br/>"
 
-#: partsmanagement/forms.py:52 partsmanagement/models.py:82
+#: partsmanagement/forms.py:51 partsmanagement/models.py:80
 #: templates/pmgmt/storage/detail.html:31
 msgid "Storage Type"
 msgstr "Lagertyp"
 
-#: partsmanagement/forms.py:53
-msgid "Sets the type of your to be created storage places"
-msgstr "Legt den Typ der zu erstellenden Lagerplätze fest."
+#: partsmanagement/forms.py:52
+msgid "Sets the type of your to be created storage places.<br/><br/>"
+msgstr "Legt den Typ der zu erstellenden Lagerplätze fest.<br/><br/>"
 
 #: partsmanagement/forms.py:55
 msgid "Parent"
 msgstr "Übergeordnetes Lager"
 
 #: partsmanagement/forms.py:57
-msgid "The parent storage of the new created ones"
-msgstr "Das übergeordnete Lager für die neu zu erstellenden Lagerplätze."
+msgid "The parent storage of the new created ones.<br/><br/>"
+msgstr ""
+"Das übergeordnete Lager für die neu zu erstellenden Lagerplätze.<br/><br/>"
 
-#: partsmanagement/forms.py:60
+#: partsmanagement/forms.py:61
 msgid "Columns"
 msgstr "Spalten"
 
-#: partsmanagement/forms.py:64
-msgid "The number of «columns» you need."
-msgstr "Die Anzahl an Spalten, die benötigt werden."
+#: partsmanagement/forms.py:65
+msgid "The number of «columns» you need.<br/><br/>"
+msgstr "Die Anzahl an Spalten, die benötigt werden.<br/><br/>"
 
-#: partsmanagement/forms.py:66
+#: partsmanagement/forms.py:68
 msgid "Rows"
 msgstr "Zeilen"
 
-#: partsmanagement/forms.py:70
-msgid "The number of «rows» you need."
-msgstr "Die Anzahl der Zeilen, die benötigt werden."
+#: partsmanagement/forms.py:72
+msgid "The number of «rows» you need.<br/><br/>"
+msgstr "Die Anzahl der Zeilen, die benötigt werden.<br/><br/>"
 
-#: partsmanagement/models.py:35
+#: partsmanagement/models.py:33
 msgid "Length"
 msgstr "Längen"
 
-#: partsmanagement/models.py:36
+#: partsmanagement/models.py:33
 msgid "meters"
 msgstr "Meter"
 
-#: partsmanagement/models.py:37
+#: partsmanagement/models.py:33
 msgid "centimeters"
 msgstr "Centimeter"
 
-#: partsmanagement/models.py:39
+#: partsmanagement/models.py:35
 msgid "Volume"
 msgstr "Volumen"
 
-#: partsmanagement/models.py:40
+#: partsmanagement/models.py:37
 msgid "litres"
 msgstr "Liter"
 
-#: partsmanagement/models.py:41
+#: partsmanagement/models.py:38
 msgid "cubicmeters"
 msgstr "Kubikmeter"
 
-#: partsmanagement/models.py:42
+#: partsmanagement/models.py:39
 msgid "cubic centimeters"
 msgstr "Kubikcentimeter"
 
-#: partsmanagement/models.py:44
+#: partsmanagement/models.py:42
 msgid "Piece"
 msgstr "Stück"
 
-#: partsmanagement/models.py:45
+#: partsmanagement/models.py:42
 msgid "piece"
 msgstr "Stück"
 
-#: partsmanagement/models.py:47 templates/pmgmt/storage/empty_list.html:56
+#: partsmanagement/models.py:43 templates/pmgmt/storage/empty_list.html:56
 #: templates/pmgmt/storage/list.html:59
-#: templates/pmgmt/storageitem/detail.html:49
+#: templates/pmgmt/storageitem/detail.html:57
 msgid "n/A"
 msgstr "n/V"
 
-#: partsmanagement/models.py:47
+#: partsmanagement/models.py:43
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: partsmanagement/models.py:51
+#: partsmanagement/models.py:47
 msgid "Paid"
 msgstr "Bezahlt"
 
-#: partsmanagement/models.py:52
+#: partsmanagement/models.py:48
 msgid "Open"
 msgstr "Offen"
 
-#: partsmanagement/models.py:53
+#: partsmanagement/models.py:49
 msgid "Reserverd"
 msgstr "Reserviert"
 
-#: partsmanagement/models.py:62
-msgid "The name for a storage type. Should be unique"
-msgstr "Der Name des Lagertypes. Sollte ein eindeutiger Name sein."
+#: partsmanagement/models.py:58
+msgid "The name for a storage type. Should be unique.<br/><br/>"
+msgstr "Der Name des Lagertypes. Sollte ein eindeutiger Name sein.<br/><br/>"
 
-#: partsmanagement/models.py:68 partsmanagement/models.py:146
-msgid "A short description."
-msgstr "Eine kurze Beschreibung"
+#: partsmanagement/models.py:64 partsmanagement/models.py:145
+msgid "A short description.<br/><br/>"
+msgstr "Eine kurze Beschreibung.<br/><br/>"
 
-#: partsmanagement/models.py:74
+#: partsmanagement/models.py:71
 msgid ""
 "If you have a typical image of such a storage, this is the place where it "
-"belongs to."
+"belongs to.<br/><br/>"
 msgstr ""
 "Der perfekte Platz, um ein typisches Bild für den Lagertyp zu hinterlegen."
+"<br/><br/>"
 
-#: partsmanagement/models.py:83 templates/base.html:57
+#: partsmanagement/models.py:81 templates/base.html:62
 msgid "Storage Types"
 msgstr "Lagertypen"
 
-#: partsmanagement/models.py:105
-msgid "A name for the storage place.E.g. coordinates inside a book shelve."
+#: partsmanagement/models.py:103
+msgid ""
+"A name for the storage place.E.g. coordinates inside a book shelve.<br/><br/>"
 msgstr ""
 "Ein treffender Name für den Lagerplatz. Z.B. Koordinaten innerhalb eines "
-"Bücherregals."
+"Bücherregals.<br/><br/>"
 
-#: partsmanagement/models.py:110
-msgid "Of which type is the storage place."
-msgstr "Von welchem Typ ist der Lagerplatz."
+#: partsmanagement/models.py:109
+msgid "Of which type is the storage place.<br/><br/>"
+msgstr "Von welchem Typ ist der Lagerplatz.<br/><br/>"
 
-#: partsmanagement/models.py:119 partsmanagement/models.py:646
+#: partsmanagement/models.py:118 partsmanagement/models.py:658
 msgid "Owned by"
 msgstr "Gehört"
 
-#: partsmanagement/models.py:120
-msgid "The user who is responsible for the storage."
-msgstr "Der Nutzer, der verantwortlich für den Lagerplatz zeichnet."
+#: partsmanagement/models.py:119
+msgid "The user who is responsible for the storage.<br/><br/>"
+msgstr "Der Nutzer, der verantwortlich für den Lagerplatz zeichnet.<br/><br/>"
 
-#: partsmanagement/models.py:128 templates/pmgmt/storage/detail.html:51
+#: partsmanagement/models.py:127 templates/pmgmt/storage/detail.html:51
 msgid "Parent storage"
 msgstr "Übergeorndetes Lager"
 
-#: partsmanagement/models.py:129
-msgid "The storage the current storage is part of."
-msgstr "Ein Lagerplatz, in der der aktuelle Lagerplatz liegt."
+#: partsmanagement/models.py:128
+msgid "The storage the current storage is part of.<br/><br/>"
+msgstr "Ein Lagerplatz, in der der aktuelle Lagerplatz liegt.<br/><br/>"
 
-#: partsmanagement/models.py:132 partsmanagement/models.py:492
-#: partsmanagement/models.py:638
+#: partsmanagement/models.py:131 partsmanagement/models.py:499
+#: partsmanagement/models.py:650
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: partsmanagement/models.py:134
-msgid "Whether a storage is active."
-msgstr "Steuert, ob der aktuelle Lagerplatz zur Verfügung steht."
+#: partsmanagement/models.py:133
+msgid "Whether a storage is active.<br/><br/>"
+msgstr "Steuert, ob der aktuelle Lagerplatz zur Verfügung steht.<br/><br/>"
 
-#: partsmanagement/models.py:140
-msgid "So does look the place in real."
-msgstr "So sieht der Lagerplatz »in echt« aus."
+#: partsmanagement/models.py:139
+msgid "So does look the place in real.<br/><br/>"
+msgstr "So sieht der Lagerplatz »in echt« aus.<br/><br/>"
 
-#: partsmanagement/models.py:166
+#: partsmanagement/models.py:167
 #, python-format
 msgid "There seems to be a circle insideancestors at %s."
 msgstr ""
 "Es scheint ein Kreis-Problem mit der übergeordneten Kategorie %s zu geben."
 
-#: partsmanagement/models.py:216
+#: partsmanagement/models.py:220
 msgid "The storage cannot be one of its ancestors"
 msgstr "Ein Lager kann sich nicht in sich selbst befinden."
 
-#: partsmanagement/models.py:220
+#: partsmanagement/models.py:224
 msgid "Storage Place"
 msgstr "Lagerplatz"
 
-#: partsmanagement/models.py:221
+#: partsmanagement/models.py:225
 msgid "Storage Places"
 msgstr "Lagerplätze"
 
-#: partsmanagement/models.py:230
-msgid "Name of the manufacturer."
-msgstr "Name des Herstellers"
+#: partsmanagement/models.py:233
+msgid "Name of the manufacturer.<br/><br/>"
+msgstr "Name des Herstellers.<br/><br/>"
 
-#: partsmanagement/models.py:236 partsmanagement/models.py:279
-msgid "The logo of the company."
-msgstr "Das Logo der Firma."
+#: partsmanagement/models.py:239 partsmanagement/models.py:281
+msgid "The logo of the company.<br/><br/>"
+msgstr "Das Logo der Firma.<br/><br/>"
 
-#: partsmanagement/models.py:241
-msgid "The URL to homepage of manufacturer."
-msgstr "Die Adresse der Homepage des Herstellers."
+#: partsmanagement/models.py:244
+msgid "The URL to homepage of manufacturer.<br/><br/>"
+msgstr "Die Adresse der Homepage des Herstellers.<br/><br/>"
 
-#: partsmanagement/models.py:245
-msgid "Timestamp the manufacturer was created at."
-msgstr "Der Zeitpunkt, zu dem der Hersteller angelegt wurde."
+#: partsmanagement/models.py:248
+msgid "Timestamp the manufacturer was created at.<br/><br/>"
+msgstr "Der Zeitpunkt, zu dem der Hersteller angelegt wurde.<br/><br/>"
 
-#: partsmanagement/models.py:252 partsmanagement/models.py:297
-#: partsmanagement/models.py:486
+#: partsmanagement/models.py:255 partsmanagement/models.py:299
+#: partsmanagement/models.py:493
 msgid "Added by"
 msgstr "Hinzugefügt von"
 
-#: partsmanagement/models.py:253
-msgid "The user the manufacturer was created by."
-msgstr "Der Nutzer, von dem der Hersteller angelegt wurde."
+#: partsmanagement/models.py:256
+msgid "The user the manufacturer was created by.<br/><br/>"
+msgstr "Der Nutzer, von dem der Hersteller angelegt wurde.<br/><br/>"
 
-#: partsmanagement/models.py:263 partsmanagement/models.py:452
+#: partsmanagement/models.py:266 partsmanagement/models.py:459
 #: templates/pmgmt/part/detail.html:65 templates/pmgmt/part/list.html:55
 #: templates/pmgmt/part/reorderlist.html:40
 msgid "Manufacturer"
 msgstr "Hersteller"
 
-#: partsmanagement/models.py:264 templates/base.html:55
+#: partsmanagement/models.py:267 templates/base.html:61
 #: templates/pmgmt/manufacturer/add.html:7
 #: templates/pmgmt/manufacturer/detail.html:11
 #: templates/pmgmt/manufacturer/list.html:7
@@ -286,32 +291,32 @@ msgstr "Hersteller"
 msgid "Manufacturers"
 msgstr "Hersteller"
 
-#: partsmanagement/models.py:273
-msgid "Name of the distributor"
-msgstr "Name des Lieferanten"
+#: partsmanagement/models.py:275
+msgid "Name of the distributor.<br/><br/>"
+msgstr "Name des Lieferanten.<br/><br/>"
 
-#: partsmanagement/models.py:284
-msgid "The URL to homepage of distributor."
-msgstr "Die Adresse der Homepage des Lieferanten."
+#: partsmanagement/models.py:286
+msgid "The URL to homepage of distributor.<br/><br/>"
+msgstr "Die Adresse der Homepage des Lieferanten.<br/><br/>"
 
-#: partsmanagement/models.py:288 partsmanagement/models.py:480
+#: partsmanagement/models.py:290 partsmanagement/models.py:487
 msgid "Creation time"
 msgstr "Angelegt am"
 
-#: partsmanagement/models.py:290
-msgid "Timestamp the distributor was created at."
-msgstr "Zeitpunkt, an dem der Lieferant erstellt wurde."
+#: partsmanagement/models.py:292
+msgid "Timestamp the distributor was created at.<br/><br/>"
+msgstr "Zeitpunkt, an dem der Lieferant erstellt wurde.<br/><br/>"
 
-#: partsmanagement/models.py:298
-msgid "User who created the distributor."
-msgstr "Nutzer der den Lieferanten als gelöscht markiert hat."
+#: partsmanagement/models.py:300
+msgid "User who created the distributor.<br/><br/>"
+msgstr "Nutzer der den Lieferanten als gelöscht markiert hat.<br/><br/>"
 
-#: partsmanagement/models.py:305 partsmanagement/models.py:460
+#: partsmanagement/models.py:307 partsmanagement/models.py:467
 #: templates/pmgmt/part/detail.html:57
 msgid "Distributor"
 msgstr "Lieferant"
 
-#: partsmanagement/models.py:306 templates/base.html:54
+#: partsmanagement/models.py:308 templates/base.html:60
 #: templates/pmgmt/distributor/add.html:7
 #: templates/pmgmt/distributor/detail.html:10
 #: templates/pmgmt/distributor/list.html:7
@@ -319,307 +324,316 @@ msgstr "Lieferant"
 msgid "Distributors"
 msgstr "Lieferanten"
 
-#: partsmanagement/models.py:316
-msgid "Name of the category."
-msgstr "Name der Kategorie des Teils."
+#: partsmanagement/models.py:317
+msgid "Name of the category.<br/><br/>"
+msgstr "Name der Kategorie des Teils.<br/><br/>"
 
-#: partsmanagement/models.py:323
-msgid "If having a subcateogry, the parent."
-msgstr "Bei einer Unterkategorie die nächst höhere Ebene."
+#: partsmanagement/models.py:324
+msgid "If having a subcateogry, the parent.<br/><br/>"
+msgstr "Bei einer Unterkategorie die nächst höhere Ebene.<br/><br/>"
 
-#: partsmanagement/models.py:329
-msgid "A short summarize of this category."
-msgstr "Eine Zusammenfassung der Kategorie"
+#: partsmanagement/models.py:330
+msgid "A short summarize of this category.<br/><br/>"
+msgstr "Eine Zusammenfassung der Kategorie.<br/><br/>"
 
-#: partsmanagement/models.py:335
-msgid "Some picutre for category."
-msgstr "Ein Bild für die Kategorie."
+#: partsmanagement/models.py:336
+msgid "Some picutre for category.<br/><br/>"
+msgstr "Ein Bild für die Kategorie.<br/><br/>"
 
-#: partsmanagement/models.py:356
+#: partsmanagement/models.py:358
 msgid "There seems to be a circle inside ancestors of {}."
 msgstr ""
 "Es scheint ein Kreis-Problem mit der übergeordneten Kategorie »{}« zu geben."
 
-#: partsmanagement/models.py:374
+#: partsmanagement/models.py:381
 msgid "The category cannot be one of its ancestors."
 msgstr "Eine Kategorie kann nicht Teil ihrer selbst sein."
 
-#: partsmanagement/models.py:387 partsmanagement/models.py:476
+#: partsmanagement/models.py:395 partsmanagement/models.py:483
 #: templates/pmgmt/category/add.html:7
 msgid "Category"
 msgstr "Kategorie"
 
-#: partsmanagement/models.py:388 templates/base.html:53 templates/index.html:19
+#: partsmanagement/models.py:396 templates/base.html:59 templates/index.html:19
 #: templates/pmgmt/category/detail.html:7 templates/pmgmt/category/list.html:7
 #: templates/pmgmt/category/update.html:7 templates/pmgmt/part/detail.html:81
 msgid "Categories"
 msgstr "Kategorien"
 
-#: partsmanagement/models.py:396
+#: partsmanagement/models.py:404
 msgid "Name of part"
 msgstr "Name des Teils"
 
-#: partsmanagement/models.py:398
-msgid "Name of the part."
-msgstr "Name des Teils"
+#: partsmanagement/models.py:405
+msgid "Name of the part.<br/><br/>"
+msgstr "Name des Teils.<br/><br/>"
 
-#: partsmanagement/models.py:401 templates/pmgmt/part/detail.html:37
+#: partsmanagement/models.py:408 templates/pmgmt/part/detail.html:37
 msgid "SKU"
 msgstr "SKU"
 
-#: partsmanagement/models.py:404
-msgid "A installation unique idendifier for the part."
-msgstr "Ein eindeutiger Bezeichner für das Teil."
+#: partsmanagement/models.py:411
+msgid "A installation unique idendifier for the part.<br/><br/>"
+msgstr "Ein eindeutiger Bezeichner für das Teil.<br/><br/>"
 
-#: partsmanagement/models.py:412
-msgid "A long text description of the part"
-msgstr "Eine ausführliche Beschreibung des Teiles."
+#: partsmanagement/models.py:419
+msgid "A long text description of the part<br/><br/>"
+msgstr "Eine ausführliche Beschreibung des Teiles.<br/><br/>"
 
-#: partsmanagement/models.py:415
+#: partsmanagement/models.py:422
 msgid "Minimal stock"
 msgstr "Mindestlagerbestand"
 
-#: partsmanagement/models.py:420
-msgid "Set a minimum that should be stored."
-msgstr "Setzt einen Minimalwert, wie viele Teile vorhanden sein müssen/sollen."
+#: partsmanagement/models.py:427
+msgid "Set a minimum that should be stored.<br/><br/>"
+msgstr ""
+"Setzt einen Minimalwert, wie viele Teile vorhanden sein müssen/sollen.<br/"
+"><br/>"
 
-#: partsmanagement/models.py:423
+#: partsmanagement/models.py:430
 msgid "Messuring unit"
 msgstr "Maßeinheit"
 
-#: partsmanagement/models.py:428
-msgid "The unit quantities are in."
-msgstr "Die Maßeinheit, in der das Teil gemessen wird."
+#: partsmanagement/models.py:435
+msgid "The unit quantities are in.<br/><br/>"
+msgstr "Die Maßeinheit, in der das Teil gemessen wird.<br/><br/>"
 
-#: partsmanagement/models.py:434
-msgid "The actual image."
-msgstr "Ein Bild des Teiles."
+#: partsmanagement/models.py:441
+msgid "The actual image.<br/><br/>"
+msgstr "Ein Bild des Teiles.<br/><br/>"
 
-#: partsmanagement/models.py:440
-msgid "The URL of the original image."
-msgstr "Die URL des originalen Bildes."
+#: partsmanagement/models.py:447
+msgid "The URL of the original image.<br/><br/>"
+msgstr "Die URL des originalen Bildes.<br/><br/>"
 
-#: partsmanagement/models.py:443 templates/pmgmt/part/detail.html:104
+#: partsmanagement/models.py:450 templates/pmgmt/part/detail.html:114
 msgid "Data sheet"
 msgstr "Datenblatt"
 
-#: partsmanagement/models.py:444
-msgid "A document containing important addition information"
-msgstr "Ein Dokument, welches zusätzliche Informationen enthält."
+#: partsmanagement/models.py:451
+msgid "A document containing important addition information.<br/><br/>"
+msgstr "Ein Dokument, welches zusätzliche Informationen enthält.<br/><br/>"
 
-#: partsmanagement/models.py:456
-msgid "The manufacturer of the part."
-msgstr "Der Hersteller des Teiles."
+#: partsmanagement/models.py:463
+msgid "The manufacturer of the part.<br/><br/>"
+msgstr "Der Hersteller des Teiles.<br/><br/>"
 
-#: partsmanagement/models.py:464
-msgid "The usual distributor of the part."
-msgstr "Der übliche Lieferant des Teiles."
+#: partsmanagement/models.py:471
+msgid "The usual distributor of the part.<br/><br/>"
+msgstr "Der übliche Lieferant des Teiles.<br/><br/>"
 
-#: partsmanagement/models.py:467
+#: partsmanagement/models.py:474
 msgid "Cost of the part"
 msgstr "Kosten/Preis des Teils"
 
-#: partsmanagement/models.py:468
-msgid "The cost/price for the part"
-msgstr "Die Kosten bzw. der Preis für ein Teil."
+#: partsmanagement/models.py:475
+msgid "The cost/price for the part.<br/><br/>"
+msgstr "Die Kosten bzw. der Preis für ein Teil.<br/><br/>"
 
-#: partsmanagement/models.py:477
-msgid "A list of categories the part is in."
-msgstr "Eine Liste mit Kategorien zu denen das Teil gezählt werden kann."
+#: partsmanagement/models.py:484
+msgid "A list of categories the part is in.<br/><br/>"
+msgstr ""
+"Eine Liste mit Kategorien zu denen das Teil gezählt werden kann.<br/><br/>"
 
-#: partsmanagement/models.py:482
-msgid "Timestamp the part was created on."
-msgstr "Zeitpunkt an dem das Teil erstellt wurde."
-
-#: partsmanagement/models.py:487
-msgid "The user the part was created by."
-msgstr "Der Nutzer, der das Teil erstellt hat."
+#: partsmanagement/models.py:489
+msgid "Timestamp the part was created on.<br/><br/>"
+msgstr "Zeitpunkt an dem das Teil erstellt wurde.<br/><br/>"
 
 #: partsmanagement/models.py:494
-msgid "Whether the part is active or not."
-msgstr "Zeigt ab, ob das Teil aktiv oder inaktiv ist."
+msgid "The user the part was created by.<br/><br/>"
+msgstr "Der Nutzer, der das Teil erstellt hat.<br/><br/>"
 
-#: partsmanagement/models.py:602 templates/pmgmt/storageitem/detail.html:33
+#: partsmanagement/models.py:501
+msgid "Whether the part is active or not.<br/><br/>"
+msgstr "Zeigt ab, ob das Teil aktiv oder inaktiv ist.<br/><br/>"
+
+#: partsmanagement/models.py:614 templates/pmgmt/storageitem/detail.html:41
 #: templates/pmgmt/storageitem/list.html:40
 #: templates/pmgmt/storageitem/list_review.html:40
 msgid "Part"
 msgstr "Teil"
 
-#: partsmanagement/models.py:603 templates/base.html:30 templates/index.html:17
+#: partsmanagement/models.py:615 templates/base.html:30 templates/index.html:17
 #: templates/pmgmt/category/detail.html:32 templates/pmgmt/part/add.html:7
 #: templates/pmgmt/part/delete.html:6 templates/pmgmt/part/detail.html:7
 #: templates/pmgmt/part/list.html:7 templates/pmgmt/part/update.html:7
 msgid "Parts"
 msgstr "Teile"
 
-#: partsmanagement/models.py:610
-msgid "The part stored at this spot."
-msgstr "Das Teil, welches an dieser Stelle gelagert ist"
+#: partsmanagement/models.py:622
+msgid "The part stored at this spot.<br/><br/>"
+msgstr "Das Teil, welches an dieser Stelle gelagert ist.<br/><br/>"
 
-#: partsmanagement/models.py:615
-msgid "The storage the part is stored in."
-msgstr "Der Lagerplatz, an dem das Teil eingelagert ist."
+#: partsmanagement/models.py:627
+msgid "The storage the part is stored in.<br/><br/>"
+msgstr "Der Lagerplatz, an dem das Teil eingelagert ist.<br/><br/>"
 
-#: partsmanagement/models.py:619
+#: partsmanagement/models.py:631
 msgid "Parts inside storage"
 msgstr "Teile innerhalb des Lagers"
 
-#: partsmanagement/models.py:624
-msgid "The amount currently stored."
-msgstr "Die Menge an Teilen, die dort aktuell gelagert sind."
+#: partsmanagement/models.py:636
+msgid "The amount currently stored.<br/><br/>"
+msgstr "Die Menge an Teilen, die dort aktuell gelagert sind.<br/><br/>"
 
-#: partsmanagement/models.py:627
+#: partsmanagement/models.py:639
 msgid "Needs review"
 msgstr "Zur Wiedervorlage"
 
-#: partsmanagement/models.py:629
-msgid "Whether this storage item might be wrong"
-msgstr "Entscheidet, ob der Eintrag nochmal geprüften werden sollte."
+#: partsmanagement/models.py:641
+msgid "Whether this storage item might be wrong.<br/><br/>"
+msgstr "Entscheidet, ob der Eintrag nochmal geprüften werden sollte.<br/><br/>"
 
-#: partsmanagement/models.py:632
+#: partsmanagement/models.py:644
 msgid "Reason for Review"
 msgstr "Grund zur Wiedervorlage"
 
-#: partsmanagement/models.py:635
-msgid "Put reason, why this item should be reviewed here in."
-msgstr "Den Grund für die Wiedervorlage hier einstellen."
-
-#: partsmanagement/models.py:640
-msgid "Whether the storage item is active."
-msgstr "Entscheidet, ob der Eintrag aktiv ist."
-
 #: partsmanagement/models.py:647
-msgid "The user owning items of this storageitem."
-msgstr "Der Nutzer, dem die Teile aus der Einlagerung gehören."
+msgid "Put reason, why this item should be reviewed here in.<br/><br/>"
+msgstr "Den Grund für die Wiedervorlage hier einstellen.<br/><br/>"
 
-#: partsmanagement/models.py:693 templates/pmgmt/transaction/detail.html:29
+#: partsmanagement/models.py:652
+msgid "Whether the storage item is active.<br/><br/>"
+msgstr "Entscheidet, ob der Eintrag aktiv ist.<br/><br/>"
+
+#: partsmanagement/models.py:659
+msgid "The user owning items of this storageitem.<br/><br/>"
+msgstr "Der Nutzer, dem die Teile aus der Einlagerung gehören.<br/><br/>"
+
+#: partsmanagement/models.py:723 templates/pmgmt/transaction/detail.html:29
 msgid "Storage Item"
 msgstr "Einlagerung"
 
-#: partsmanagement/models.py:694 templates/pmgmt/storageitem/detail.html:10
+#: partsmanagement/models.py:724 templates/pmgmt/storageitem/detail.html:10
 #: templates/pmgmt/storageitem/list.html:7
 msgid "Storage Items"
 msgstr "Einlagerungen"
 
-#: partsmanagement/models.py:701
-msgid "The part-storage relation the the stock was verified."
-msgstr "Die Einlagerung, für die der Lagerstand verifiziert wurde."
+#: partsmanagement/models.py:731
+msgid "The part-storage relation the the stock was verified.<br/><br/>"
+msgstr "Die Einlagerung, für die der Lagerstand verifiziert wurde.<br/><br/>"
 
-#: partsmanagement/models.py:704 partsmanagement/models.py:748
+#: partsmanagement/models.py:735 partsmanagement/models.py:782
 #: templates/pmgmt/transaction/detail.html:33
 msgid "Amount"
 msgstr "Menge"
 
-#: partsmanagement/models.py:707
-msgid "The quantity at this very time."
-msgstr "Die Menge zum Stichtag."
+#: partsmanagement/models.py:738
+msgid "The quantity at this very time.<br/><br/>"
+msgstr "Die Menge zum Stichtag.<br/><br/>"
 
-#: partsmanagement/models.py:709 partsmanagement/models.py:754
+#: partsmanagement/models.py:741 partsmanagement/models.py:788
 msgid "Comment"
 msgstr "Kommentar"
 
-#: partsmanagement/models.py:713 partsmanagement/models.py:758
-msgid "A short conclusion."
-msgstr "Eine kurze Zusammenfassung."
+#: partsmanagement/models.py:745
+msgid "A short conclusion.<br/><br/>"
+msgstr "Eine kurze Zusammenfassung.<br/><br/>"
 
-#: partsmanagement/models.py:716
+#: partsmanagement/models.py:748
 msgid "Verfication Date"
 msgstr "Verifikationszeitpunkt"
 
-#: partsmanagement/models.py:721
-msgid "The date the verifiedcation was created."
-msgstr "Der Stichtag, an dem der Bestand verifiziert wurde."
+#: partsmanagement/models.py:753
+msgid "The date the verifiedcation was created.<br/><br/>"
+msgstr "Der Stichtag, an dem der Bestand verifiziert wurde.<br/><br/>"
 
-#: partsmanagement/models.py:725 partsmanagement/models.py:779
+#: partsmanagement/models.py:757 partsmanagement/models.py:813
 #: templates/pmgmt/transaction/detail.html:37
 msgid "Created by"
 msgstr "Erstellt von"
 
-#: partsmanagement/models.py:726
-msgid "The user which verified the stock."
-msgstr "Der Nutzer, der den Bestand verifiziert hat."
+#: partsmanagement/models.py:758
+msgid "The user which verified the stock.<br/><br/>"
+msgstr "Der Nutzer, der den Bestand verifiziert hat.<br/><br/>"
 
-#: partsmanagement/models.py:738 templates/pmgmt/transaction/detail.html:25
+#: partsmanagement/models.py:770 templates/pmgmt/transaction/detail.html:25
 msgid "Subject"
 msgstr "Kurzbeschreibung"
 
-#: partsmanagement/models.py:740
-msgid "A short conclusion of the transaction."
-msgstr "Eine kurze Zusammenfassung für die Transaktion."
+#: partsmanagement/models.py:772
+msgid "A short conclusion of the transaction.<br/><br/>"
+msgstr "Eine kurze Zusammenfassung für die Transaktion.<br/><br/>"
 
-#: partsmanagement/models.py:744
-msgid "The part-storage relation the transaction was applied on."
-msgstr "Die Einlagerung, auf die bei der Transaktion zurück gegriffen wurde."
+#: partsmanagement/models.py:777
+msgid "The part-storage relation the transaction was applied on.<br/><br/>"
+msgstr ""
+"Die Einlagerung, auf die bei der Transaktion zurück gegriffen wurde.<br/><br/"
+">"
 
-#: partsmanagement/models.py:751
-msgid "The quantity transferred."
-msgstr "Die Menge, um die sich der Bestand geändert hat."
+#: partsmanagement/models.py:785
+msgid "The quantity transferred.<br/><br/>"
+msgstr "Die Menge, um die sich der Bestand geändert hat.<br/><br/>"
 
-#: partsmanagement/models.py:762
+#: partsmanagement/models.py:792
+msgid "Optional: A short conclusion.<br/><br/>"
+msgstr "Eine kurze Zusammenfassung.<br/><br/>"
+
+#: partsmanagement/models.py:796
 msgid "Transaction Date"
 msgstr "Transaktionsdaten"
 
-#: partsmanagement/models.py:767
-msgid "The date the transaction took  part."
-msgstr "Das Datum, an dem die Transaktion stattfand."
+#: partsmanagement/models.py:801
+msgid "The date the transaction took part.<br/><br/>"
+msgstr "Das Datum, an dem die Transaktion stattfand.<br/><br/>"
 
-#: partsmanagement/models.py:770
+#: partsmanagement/models.py:804
 msgid "State"
 msgstr "Status"
 
-#: partsmanagement/models.py:775
-msgid "The status a transaction is in."
-msgstr "Der Status in der sich die Transaktion befindet."
+#: partsmanagement/models.py:809
+msgid "The status a transaction is in.<br/><br/>"
+msgstr "Der Status in der sich die Transaktion befindet.<br/><br/>"
 
-#: partsmanagement/models.py:780
-msgid "The user which created the transaction."
-msgstr "Der Nutzer, die die Transaktion anlegte."
+#: partsmanagement/models.py:814
+msgid "The user which created the transaction.<br/><br/>"
+msgstr "Der Nutzer, die die Transaktion anlegte.<br/><br/>"
 
-#: partsmanagement/models.py:784
+#: partsmanagement/models.py:818
 msgid "Creation timestamp"
 msgstr "Angelegt am"
 
-#: partsmanagement/models.py:789
-msgid "The timestamp transaction has been entered."
-msgstr "Der Zeitpunkt zu dem die Transaktion angelegt wurde."
+#: partsmanagement/models.py:823
+msgid "The timestamp transaction has been entered.<br/><br/>"
+msgstr "Der Zeitpunkt zu dem die Transaktion angelegt wurde.<br/><br/>"
 
-#: partsmanagement/models.py:793
+#: partsmanagement/models.py:827
 msgid "Reverted"
 msgstr "Zurück gerollt"
 
-#: partsmanagement/models.py:796
+#: partsmanagement/models.py:830
 msgid ""
 "To control whether transaction has been already reverted and cannot be "
-"reverted again."
+"reverted again.<br/><br/>"
 msgstr ""
 "Gibt an, ob die Transaktion bereits zurück gerollt, das heißt widerrufen "
-"wurde, und so nicht mehr neu entsprechend behandelt werden kann."
+"wurde, und so nicht mehr neu entsprechend behandelt werden kann.<br/><br/>"
 
-#: partsmanagement/models.py:803
+#: partsmanagement/models.py:838
 msgid "reverted {}"
 msgstr "zurück {}"
 
-#: partsmanagement/models.py:813
+#: partsmanagement/models.py:848
 msgid "Transaktion »{}« was already reverted."
 msgstr "Die Transatkion »{}« wurde bereits zurück gerollt."
 
-#: partsmanagement/models.py:829
+#: partsmanagement/models.py:863
 msgid "moved {}"
 msgstr "geändert {}"
 
-#: partsmanagement/models.py:868 templates/pmgmt/storageitem/detail.html:58
+#: partsmanagement/models.py:904 templates/pmgmt/storageitem/detail.html:66
 #: templates/pmgmt/storageitem/list.html:64
 #: templates/pmgmt/transaction/detail.html:6
 msgid "Transaction"
 msgstr "Transaktion"
 
-#: partsmanagement/models.py:869 templates/base.html:44
+#: partsmanagement/models.py:905 templates/base.html:50
 #: templates/pmgmt/transaction/list.html:6
 msgid "Transactions"
 msgstr "Transaktionen"
 
 #: templates/about.html:5 templates/about.html:8 templates/about.html:10
-#: templates/base.html:119
+#: templates/base.html:124
 msgid "About"
 msgstr "Über"
 
@@ -640,8 +654,8 @@ msgid ""
 "You can fetch the source code from <a href=\"https://github.com/frlan/"
 "partuniverse\">github.com</a>"
 msgstr ""
-"Du kannst Dir die Quellen von <a href=\"http://github.com/frlan/partuniverse"
-"\">github.com</a> herunterladen."
+"Du kannst Dir die Quellen von <a href=\"http://github.com/frlan/"
+"partuniverse\">github.com</a> herunterladen."
 
 #: templates/account/delete.html:6 templates/account/password_change.html:7
 #: templates/account/settings.html:7
@@ -767,8 +781,8 @@ msgstr "Bestätige Deine Email-Adresse"
 msgid ""
 "We have sent you an email to <b>%(email)s</b> for verification. Follow the "
 "link provided to finalize the signup process. If you do not receive it "
-"within a few minutes, contact us at <a href=\"mailto:%(THEME_CONTACT_EMAIL)s"
-"\">%(THEME_CONTACT_EMAIL)s</a>."
+"within a few minutes, contact us at <a href=\"mailto:"
+"%(THEME_CONTACT_EMAIL)s\">%(THEME_CONTACT_EMAIL)s</a>."
 msgstr ""
 "Wir haben Dir eine Email an <b>%(email)s</b> zur Bestätigung gesendet. <br> "
 "Folge der Anleitung in dieser Mail, um den Registrierungsprozess "
@@ -799,7 +813,7 @@ msgstr "Einloggen"
 msgid "Forgot your password?"
 msgstr "Passwort vergessen?"
 
-#: templates/account/logout.html:6 templates/base.html:72
+#: templates/account/logout.html:6 templates/base.html:77
 msgid "Logout"
 msgstr "Ausloggen"
 
@@ -850,8 +864,8 @@ msgstr "Mein Passwort zurück setzen"
 #: templates/account/password_reset.html:25
 #, python-format
 msgid ""
-"If you have any trouble resetting your password, contact us at <a href="
-"\"mailto:%(THEME_CONTACT_EMAIL)s\">%(THEME_CONTACT_EMAIL)s</a>."
+"If you have any trouble resetting your password, contact us at <a "
+"href=\"mailto:%(THEME_CONTACT_EMAIL)s\">%(THEME_CONTACT_EMAIL)s</a>."
 msgstr ""
 "Wenn Du Probleme beim rücksetzen Deines Passwortes hast, kontaktiere uns "
 "über <a href=\"mailto:%(THEME_CONTACT_EMAIL)s\">%(THEME_CONTACT_EMAIL)s</a>. "
@@ -864,8 +878,8 @@ msgstr "»Passwort zurücksetzen«-E-Mail wurde versendet."
 #, python-format
 msgid ""
 "We have sent you an email. If you do not receive it within a few minutes, "
-"try resending or contact us at <a href=\"mailto:%(THEME_CONTACT_EMAIL)s\">"
-"%(THEME_CONTACT_EMAIL)s</a>."
+"try resending or contact us at <a href=\"mailto:"
+"%(THEME_CONTACT_EMAIL)s\">%(THEME_CONTACT_EMAIL)s</a>."
 msgstr ""
 "Wir haben Dir eine Email gesendet. Solltest Du diese nicht innerhalb der "
 "nächsten Minuten erhalten, versuche sie erneut zu senden oder kontaktiere "
@@ -905,8 +919,8 @@ msgid ""
 "used.  Please request a <a href=\"%(url)s\">new password reset</a>."
 msgstr ""
 "Der Link zum Zurücksetzen des Passwortes was leider ungültig. Es könnte "
-"sein, dass er schon einmal verwendet wurde. Bitte frage einen <a href="
-"\"%(url)s\">neuen Link</a> an."
+"sein, dass er schon einmal verwendet wurde. Bitte frage einen <a "
+"href=\"%(url)s\">neuen Link</a> an."
 
 #: templates/account/settings.html:10 templates/account/settings.html:12
 msgid "Account settings"
@@ -929,7 +943,7 @@ msgstr "Passwort"
 msgid "Sign up"
 msgstr "Registrieren"
 
-#: templates/account/signup.html:18 templates/base.html:86
+#: templates/account/signup.html:18 templates/base.html:91
 msgid "Register"
 msgstr "Registrieren"
 
@@ -945,7 +959,7 @@ msgstr "Wenn Du einen Token hast, kannst Du ihn hier eingeben."
 msgid "en"
 msgstr "de"
 
-#: templates/base.html:23 templates/base.html:97
+#: templates/base.html:23 templates/base.html:102
 msgid "Home"
 msgstr "Start"
 
@@ -953,11 +967,7 @@ msgstr "Start"
 msgid "Storage items"
 msgstr "Einlagerungen"
 
-#: templates/base.html:50
-msgid "Manage"
-msgstr "Verwalten"
-
-#: templates/base.html:56 templates/pmgmt/storage/detail.html:7
+#: templates/base.html:42 templates/pmgmt/storage/detail.html:7
 #: templates/pmgmt/storage/empty_list.html:7
 #: templates/pmgmt/storage/list.html:7 templates/pmgmt/storage/update.html:7
 #: templates/pmgmt/storagetype/detail.html:8
@@ -965,27 +975,31 @@ msgstr "Verwalten"
 msgid "Storages"
 msgstr "Lager"
 
-#: templates/base.html:58
+#: templates/base.html:56
+msgid "Manage"
+msgstr "Verwalten"
+
+#: templates/base.html:63
 msgid "Parts needs reordering"
 msgstr "Notwendige Neubestellungen"
 
-#: templates/base.html:59
+#: templates/base.html:64
 msgid "Storage items review"
 msgstr "Einlagerungen zur Überprüfung"
 
-#: templates/base.html:60
+#: templates/base.html:65
 msgid "Empty storage places"
 msgstr "Leere Lagerplätze"
 
-#: templates/base.html:66
+#: templates/base.html:71
 msgid "Edit user settings"
 msgstr "Nutzereinstellungen ändern"
 
-#: templates/base.html:81
+#: templates/base.html:86
 msgid "Login"
 msgstr "Einloggen"
 
-#: templates/base.html:114 templates/help.html:5 templates/help.html:8
+#: templates/base.html:119 templates/help.html:5 templates/help.html:8
 #: templates/help.html:10
 msgid "Help"
 msgstr "Hilfe"
@@ -1058,8 +1072,8 @@ msgstr "Häufig gestellte Fragen"
 #: templates/help.html:14
 msgid ""
 "<p>No frequently questions by now.</p>\n"
-"    <p>Please check our <a href=\"https://github.com/frlan/partuniverse/wiki"
-"\">github</a> wiki for some additional documentation.</p>"
+"    <p>Please check our <a href=\"https://github.com/frlan/partuniverse/"
+"wiki\">github</a> wiki for some additional documentation.</p>"
 msgstr ""
 "Keine häufigen Fragen bis jetzt.</p><p>Besuche doch unsere Wiki-Seite bei <a "
 "href=<a href=\"https://github.com/frlan/partuniverse/wiki\">github</a> um "
@@ -1092,11 +1106,11 @@ msgstr "Lagerplätze"
 #: templates/pmgmt/manufacturer/add.html:9
 #: templates/pmgmt/manufacturer/add.html:20
 #: templates/pmgmt/manufacturer/list.html:26 templates/pmgmt/part/add.html:9
-#: templates/pmgmt/part/add.html:20 templates/pmgmt/part/list.html:26
+#: templates/pmgmt/part/add.html:19 templates/pmgmt/part/list.html:26
 #: templates/pmgmt/storage/add.html:9 templates/pmgmt/storage/add.html:22
 #: templates/pmgmt/storage/bulkadd.html:15
 #: templates/pmgmt/storage/empty_list.html:30
-#: templates/pmgmt/storage/list.html:27 templates/pmgmt/storageitem/add.html:20
+#: templates/pmgmt/storage/list.html:27 templates/pmgmt/storageitem/add.html:19
 #: templates/pmgmt/storageitem/add_part.html:21
 #: templates/pmgmt/storageitem/list.html:26
 #: templates/pmgmt/storageitem/stocktaking.html:16
@@ -1114,15 +1128,15 @@ msgstr "Ein neue Kategorie anlegen"
 msgid "No parts by now."
 msgstr "Aktuell keine Teile."
 
-#: templates/pmgmt/category/detail.html:54 templates/pmgmt/part/detail.html:117
+#: templates/pmgmt/category/detail.html:54 templates/pmgmt/part/detail.html:127
 msgid "No picture available"
 msgstr "Keine passenden Bild verfügbar."
 
 #: templates/pmgmt/category/detail.html:59
 #: templates/pmgmt/distributor/detail.html:45
-#: templates/pmgmt/part/detail.html:124 templates/pmgmt/part/update.html:11
+#: templates/pmgmt/part/detail.html:134 templates/pmgmt/part/update.html:11
 #: templates/pmgmt/storage/detail.html:86
-#: templates/pmgmt/storageitem/detail.html:56
+#: templates/pmgmt/storageitem/detail.html:64
 #: templates/pmgmt/storagetype/detail.html:58
 msgid "Update item"
 msgstr "Bearbeiten"
@@ -1279,23 +1293,23 @@ msgstr "Keine Beschreibung verfügbar."
 msgid "Storage Item(s)"
 msgstr "Einlagerung(en)"
 
-#: templates/pmgmt/part/detail.html:91
+#: templates/pmgmt/part/detail.html:96
 msgid "Update stock"
 msgstr "Bestand ändern"
 
-#: templates/pmgmt/part/detail.html:93
+#: templates/pmgmt/part/detail.html:100
 msgid "(unknown quantity on stock)"
 msgstr "(Menge unbekannt)"
 
-#: templates/pmgmt/part/detail.html:95
+#: templates/pmgmt/part/detail.html:102
 msgid "Detail"
 msgstr "Mehr"
 
-#: templates/pmgmt/part/detail.html:99
+#: templates/pmgmt/part/detail.html:109
 msgid "Add new"
 msgstr "Neu"
 
-#: templates/pmgmt/part/detail.html:126
+#: templates/pmgmt/part/detail.html:136
 msgid "Delete item"
 msgstr "Teil löschen"
 
@@ -1337,7 +1351,7 @@ msgid "Submit"
 msgstr "Übertragen"
 
 #: templates/pmgmt/storage/add.html:7
-#: templates/pmgmt/storageitem/detail.html:37
+#: templates/pmgmt/storageitem/detail.html:45
 #: templates/pmgmt/storageitem/list.html:41
 #: templates/pmgmt/storageitem/list_review.html:41
 #: templates/pmgmt/storagetype/add.html:7
@@ -1370,11 +1384,11 @@ msgstr "Massenanlage"
 #: templates/pmgmt/storage/bulkadd.html:11
 msgid ""
 "Bulk add multiple storage places as a rectangle given in rows and columns "
-"resulting in places like A1 or B22"
+"resulting in places like A1 or B22."
 msgstr ""
 "Fügt mehrere neue Lageplätze in logischer Form eines Rechteckes, definiert "
 "durch die Anzahl von Spalten und Zeilen, hinzu. Es entstehen Lagerplatz-"
-"Bezeichnungen wie z.B. A1 oder BB23"
+"Bezeichnungen wie z.B. A1 oder BB23."
 
 #: templates/pmgmt/storage/detail.html:27
 #: templates/pmgmt/storage/empty_list.html:46
@@ -1387,7 +1401,7 @@ msgid "no Details"
 msgstr "Keine Details"
 
 #: templates/pmgmt/storage/detail.html:44
-#: templates/pmgmt/storageitem/detail.html:42
+#: templates/pmgmt/storageitem/detail.html:50
 msgid "Owner"
 msgstr "Eigentümer"
 
@@ -1447,6 +1461,14 @@ msgstr "Einlagerung hinzufügen"
 msgid "Add a storage item"
 msgstr "Eine neue Einlagerung anlegen"
 
+#: templates/pmgmt/storageitem/add.html:15
+msgid ""
+"Use this to add a new storage items, which is a combination of a part a "
+"decent storage place. Actually: Where can I find this particular part."
+msgstr ""
+"Hier kannst du neue Einlagerungen anlegen. Eine Einlagerung besteht aus "
+"einem bestimmten Teil an einem bestimmten Ort/in einem bestimmten Lager."
+
 #: templates/pmgmt/storageitem/add_part.html:16
 #, python-format
 msgid ""
@@ -1457,6 +1479,14 @@ msgstr ""
 "Teil im Lager zu finden und den Bestand zu führen."
 
 #: templates/pmgmt/storageitem/detail.html:20
+msgid "This storage item has been marked as disbaled."
+msgstr "Diese Einlagerung wurde als deaktiviert markiert."
+
+#: templates/pmgmt/storageitem/detail.html:21
+msgid "Most likely you will not find this inside storage anymore."
+msgstr ""
+
+#: templates/pmgmt/storageitem/detail.html:28
 msgid ""
 "The storage item has been marked as to needs a review. Would you mind to "
 "check whether the part is really at this place and/or the amount registered "
@@ -1466,15 +1496,15 @@ msgstr ""
 "dass die hier gespeicherten Angaben nicht korrekt sind. Möchtest Du dabei "
 "helfen, die Daten zu korrigieren?"
 
-#: templates/pmgmt/storageitem/detail.html:23
+#: templates/pmgmt/storageitem/detail.html:31
 msgid "Reason:"
 msgstr "Grund:"
 
-#: templates/pmgmt/storageitem/detail.html:48
+#: templates/pmgmt/storageitem/detail.html:56
 msgid "On Stock"
 msgstr "Im Bestand"
 
-#: templates/pmgmt/storageitem/detail.html:57
+#: templates/pmgmt/storageitem/detail.html:65
 #: templates/pmgmt/storageitem/list.html:63
 #: templates/pmgmt/storageitem/list_review.html:63
 msgid "Stock taking"
@@ -1525,7 +1555,7 @@ msgstr "Inventur"
 #: templates/pmgmt/storageitem/stocktaking.html:12
 msgid ""
 "It will create an Transaction adjusting the amount for items on stock to "
-"reported one.."
+"reported one."
 msgstr ""
 "Dies wird eine Transaktion über die errechnete Differenz anlegen, die den "
 "aktuellen Bestand auf den eingetragenen Wert korrgiert."
@@ -1632,13 +1662,6 @@ msgstr "Wann"
 #~| msgid "Storage items"
 #~ msgid "Storage item"
 #~ msgstr "Einlagerungen"
-
-#~ msgid ""
-#~ "Use this to add new storage items, which are parts on a decent storage "
-#~ "place"
-#~ msgstr ""
-#~ "Hier kannst du neue Einlagerungen anlegen. Eine Einlagerung besteht aus "
-#~ "einem bestimmten Teil an einem bestimmten Ort/in einem bestimmten Lager."
 
 #~ msgid "Storage:"
 #~ msgstr "Lager:"

--- a/partuniverse/partsmanagement/forms.py
+++ b/partuniverse/partsmanagement/forms.py
@@ -17,7 +17,7 @@ class StockTakingForm(forms.Form):
         label=_("Parts now inside storage"),
         max_digits=10,
         decimal_places=4,
-        help_text=_("The amount of currently inside storage place."),
+        help_text=_("The amount of currently inside storage place.<br/><br/>"),
     )
 
 
@@ -39,7 +39,7 @@ class StorageItemAddTransactionForm(forms.Form):
         decimal_places=4,
         min_value=0.0001,
         help_text=_(
-            "The amount of items taken/put to storage. " "Positiv values only."
+            "The amount of items taken/put to storage. " "Positive values only.<br/><br/>"
         ),
     )
 
@@ -49,12 +49,12 @@ class BulkStorageForm(forms.Form):
         queryset=StorageType.objects.all(),
         required=True,
         label=_("Storage Type"),
-        help_text=_("Sets the type of your to be created storage places"),
+        help_text=_("Sets the type of your to be created storage places.<br/><br/>"),
     )
     parentstorage = forms.ModelChoiceField(
         label=_("Parent"),
         required=True,
-        help_text=_("The parent storage of the new created ones"),
+        help_text=_("The parent storage of the new created ones.<br/><br/>"),
         queryset=StoragePlace.objects.all(),
     )
     cols = forms.IntegerField(
@@ -62,12 +62,12 @@ class BulkStorageForm(forms.Form):
         required=True,
         max_value=100,
         min_value=1,
-        help_text=_("The number of «columns» you need."),
+        help_text=_("The number of «columns» you need.<br/><br/>"),
     )
     rows = forms.IntegerField(
         label=_("Rows"),
         required=True,
         max_value=100,
         min_value=1,
-        help_text=_("The number of «rows» you need."),
+        help_text=_("The number of «rows» you need.<br/><br/>"),
     )

--- a/partuniverse/partsmanagement/models.py
+++ b/partuniverse/partsmanagement/models.py
@@ -55,13 +55,13 @@ class StorageType(models.Model):
 
     name = models.CharField(
         max_length=50,
-        help_text=_("The name for a storage type. Should be unique"),
+        help_text=_("The name for a storage type. Should be unique.<br/><br/>"),
     )
     description = models.TextField(
         _("Description"),
         blank=True,
         null=True,
-        help_text=_("A short description."),
+        help_text=_("A short description.<br/><br/>"),
     )
     pic = models.ImageField(
         null=True,
@@ -69,7 +69,7 @@ class StorageType(models.Model):
         upload_to="uploads/storagetypes/",
         help_text=_(
             "If you have a typical image of such a storage, "
-            "this is the place where it belongs to."
+            "this is the place where it belongs to.<br/><br/>"
         ),
     )
 
@@ -101,12 +101,12 @@ class StoragePlace(models.Model):
         max_length=50,
         help_text=_(
             "A name for the storage place."
-            "E.g. coordinates inside a book shelve."
+            "E.g. coordinates inside a book shelve.<br/><br/>"
         ),
     )
     storage_type = models.ForeignKey(
         StorageType,
-        help_text=_("Of which type is the storage place."),
+        help_text=_("Of which type is the storage place.<br/><br/>"),
         on_delete=models.PROTECT,
         blank=True,
         null=True,
@@ -116,7 +116,7 @@ class StoragePlace(models.Model):
         null=True,
         blank=True,
         verbose_name=_("Owned by"),
-        help_text=_("The user who is responsible for the storage."),
+        help_text=_("The user who is responsible for the storage.<br/><br/>"),
         on_delete=models.SET_NULL,
     )
     parent = models.ForeignKey(
@@ -125,24 +125,24 @@ class StoragePlace(models.Model):
         blank=True,
         on_delete=models.CASCADE,
         verbose_name=_("Parent storage"),
-        help_text=_("The storage the current storage is part of."),
+        help_text=_("The storage the current storage is part of.<br/><br/>"),
     )
     disabled = models.BooleanField(
         _("Disabled"),
         default=False,
-        help_text=_("Whether a storage is active."),
+        help_text=_("Whether a storage is active.<br/><br/>"),
     )
     pic = models.ImageField(
         null=True,
         blank=True,
         upload_to="uploads/storageplaces/",
-        help_text=_("So does look the place in real."),
+        help_text=_("So does look the place in real.<br/><br/>"),
     )
     description = models.TextField(
         _("Description"),
         blank=True,
         null=True,
-        help_text=_("A short description."),
+        help_text=_("A short description.<br/><br/>"),
     )
 
     def __str__(self):
@@ -230,22 +230,22 @@ class Manufacturer(models.Model):
     """ Manufacturer for a particular item """
 
     name = models.CharField(
-        max_length=50, help_text=_("Name of the manufacturer.")
+        max_length=50, help_text=_("Name of the manufacturer.<br/><br/>")
     )
     logo = models.ImageField(
         null=True,
         blank=True,
         upload_to="uploads/logos/",
-        help_text=_("The logo of the company."),
+        help_text=_("The logo of the company.<br/><br/>"),
     )
     url = models.URLField(
         null=True,
         blank=True,
-        help_text=_("The URL to homepage of manufacturer."),
+        help_text=_("The URL to homepage of manufacturer.<br/><br/>"),
     )
     creation_time = models.DateTimeField(
         auto_now_add=True,
-        help_text=_("Timestamp the manufacturer was created at."),
+        help_text=_("Timestamp the manufacturer was created at.<br/><br/>"),
     )
     created_by = models.ForeignKey(
         User,
@@ -253,7 +253,7 @@ class Manufacturer(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         verbose_name=_("Added by"),
-        help_text=_("The user the manufacturer was created by."),
+        help_text=_("The user the manufacturer was created by.<br/><br/>"),
     )
 
     def get_parts(self):
@@ -272,24 +272,24 @@ class Distributor(models.Model):
     """ A distributor which is selling a particular part """
 
     name = models.CharField(
-        max_length=50, help_text=_("Name of the distributor")
+        max_length=50, help_text=_("Name of the distributor.<br/><br/>")
     )
     logo = models.ImageField(
         null=True,
         blank=True,
         upload_to="uploads/logos/",
-        help_text=_("The logo of the company."),
+        help_text=_("The logo of the company.<br/><br/>"),
     )
     url = models.URLField(
         null=True,
         blank=True,
-        help_text=_("The URL to homepage of distributor."),
+        help_text=_("The URL to homepage of distributor.<br/><br/>"),
     )
 
     creation_time = models.DateTimeField(
         _("Creation time"),
         auto_now_add=True,
-        help_text=_("Timestamp the distributor was created at."),
+        help_text=_("Timestamp the distributor was created at.<br/><br/>"),
     )
     created_by = models.ForeignKey(
         User,
@@ -297,7 +297,7 @@ class Distributor(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         verbose_name=_("Added by"),
-        help_text=_("User who created the distributor."),
+        help_text=_("User who created the distributor.<br/><br/>"),
     )
 
     def __str__(self):
@@ -314,26 +314,26 @@ class Category(models.Model):
     E.g. resistor """
 
     name = models.CharField(
-        max_length=50, help_text=_("Name of the category.")
+        max_length=50, help_text=_("Name of the category.<br/><br/>")
     )
     parent = models.ForeignKey(
         "self",
         null=True,
         blank=True,
         on_delete=models.CASCADE,
-        help_text=_("If having a subcateogry, the parent."),
+        help_text=_("If having a subcateogry, the parent.<br/><br/>"),
     )
     description = models.TextField(
         _("Description"),
         blank=True,
         null=True,
-        help_text=_("A short summarize of this category."),
+        help_text=_("A short summarize of this category.<br/><br/>"),
     )
     pic = models.ImageField(
         null=True,
         blank=True,
         upload_to="uploads/categories/",
-        help_text=_("Some picutre for category."),
+        help_text=_("Some picutre for category.<br/><br/>"),
     )
 
     def __str__(self):
@@ -401,13 +401,14 @@ class Part(models.Model):
     """ Representing a special kind of parts """
 
     name = models.CharField(
-        _("Name of part"), max_length=255, help_text=_("Name of the part.")
+        _("Name of part"), max_length=255,
+        help_text=_("Name of the part.<br/><br/>")
     )
     sku = models.CharField(
         _("SKU"),
         max_length=60,
         unique=True,
-        help_text=_("A installation unique idendifier for the part."),
+        help_text=_("A installation unique idendifier for the part.<br/><br/>"),
         null=True,
         blank=True,
     )
@@ -415,7 +416,7 @@ class Part(models.Model):
         _("Description"),
         blank=True,
         null=True,
-        help_text=_("A long text description of the part"),
+        help_text=_("A long text description of the part<br/><br/>"),
     )
     min_stock = models.DecimalField(
         _("Minimal stock"),
@@ -423,7 +424,7 @@ class Part(models.Model):
         decimal_places=4,
         null=True,
         blank=True,
-        help_text=_("Set a minimum that should be stored."),
+        help_text=_("Set a minimum that should be stored.<br/><br/>"),
     )
     unit = models.CharField(
         _("Messuring unit"),
@@ -431,23 +432,23 @@ class Part(models.Model):
         choices=UNIT_CHOICES,
         blank=False,
         default="---",
-        help_text=_("The unit quantities are in."),
+        help_text=_("The unit quantities are in.<br/><br/>"),
     )
     pic = models.ImageField(
         null=True,
         blank=True,
         upload_to=os.path.join("part"),
-        help_text=_("The actual image."),
+        help_text=_("The actual image.<br/><br/>"),
     )
     image_url = models.CharField(
         max_length=255,
         null=True,
         blank=True,
-        help_text=_("The URL of the original image."),
+        help_text=_("The URL of the original image.<br/><br/>"),
     )
     data_sheet = models.FileField(
         _("Data sheet"),
-        help_text=_("A document containing important addition information"),
+        help_text=_("A document containing important addition information.<br/><br/>"),
         upload_to="datasheets",
         validators=[validate_file_extension],
         null=True,
@@ -459,7 +460,7 @@ class Part(models.Model):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text=_("The manufacturer of the part."),
+        help_text=_("The manufacturer of the part.<br/><br/>"),
     )
     distributor = models.ForeignKey(
         Distributor,
@@ -467,11 +468,11 @@ class Part(models.Model):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text=_("The usual distributor of the part."),
+        help_text=_("The usual distributor of the part.<br/><br/>"),
     )
     price = models.DecimalField(
         _("Cost of the part"),
-        help_text=_("The cost/price for the part"),
+        help_text=_("The cost/price for the part.<br/><br/>"),
         null=True,
         blank=True,
         max_digits=6,
@@ -480,24 +481,24 @@ class Part(models.Model):
     categories = models.ManyToManyField(
         Category,
         verbose_name=_("Category"),
-        help_text=_("A list of categories the part is in."),
+        help_text=_("A list of categories the part is in.<br/><br/>"),
     )
     creation_time = models.DateTimeField(
         _("Creation time"),
         auto_now_add=True,
-        help_text=_("Timestamp the part was created on."),
+        help_text=_("Timestamp the part was created on.<br/><br/>"),
     )
     created_by = models.ForeignKey(
         User,
         verbose_name=_("Added by"),
-        help_text=_("The user the part was created by."),
+        help_text=_("The user the part was created by.<br/><br/>"),
         on_delete=models.SET_NULL,
         null=True,
     )
     disabled = models.BooleanField(
         _("Disabled"),
         default=False,
-        help_text=_("Whether the part is active or not."),
+        help_text=_("Whether the part is active or not.<br/><br/>"),
     )
 
     def __str__(self):
@@ -618,12 +619,12 @@ class Part(models.Model):
 class StorageItem(models.Model):
     part = models.ForeignKey(
         Part,
-        help_text=_("The part stored at this spot."),
+        help_text=_("The part stored at this spot.<br/><br/>"),
         on_delete=models.PROTECT,
     )
     storage = models.ForeignKey(
         StoragePlace,
-        help_text=_("The storage the part is stored in."),
+        help_text=_("The storage the part is stored in.<br/><br/>"),
         on_delete=models.PROTECT,
     )
     on_stock = models.DecimalField(
@@ -632,30 +633,30 @@ class StorageItem(models.Model):
         decimal_places=4,
         null=True,
         blank=True,
-        help_text=_("The amount currently stored."),
+        help_text=_("The amount currently stored.<br/><br/>"),
     )
     needs_review = models.BooleanField(
         _("Needs review"),
         default=False,
-        help_text=_("Whether this storage item might be wrong"),
+        help_text=_("Whether this storage item might be wrong.<br/><br/>"),
     )
     review_reason = models.TextField(
         _("Reason for Review"),
         blank=True,
         null=True,
-        help_text=_("Put reason, why this item should be reviewed here in."),
+        help_text=_("Put reason, why this item should be reviewed here in.<br/><br/>"),
     )
     disabled = models.BooleanField(
         _("Disabled"),
         default=False,
-        help_text=_("Whether the storage item is active."),
+        help_text=_("Whether the storage item is active.<br/><br/>"),
     )
     owner = models.ForeignKey(
         User,
         null=True,
         blank=True,
         verbose_name=_("Owned by"),
-        help_text=_("The user owning items of this storageitem."),
+        help_text=_("The user owning items of this storageitem.<br/><br/>"),
         on_delete=models.PROTECT,
     )
 
@@ -727,21 +728,21 @@ class StorageItem(models.Model):
 class VerifiedStock(models.Model):
     storage_item = models.ForeignKey(
         StorageItem,
-        help_text=_("The part-storage relation the the stock was verified."),
+        help_text=_("The part-storage relation the the stock was verified.<br/><br/>"),
         on_delete=models.PROTECT,
     )
     amount = models.DecimalField(
         _("Amount"),
         max_digits=10,
         decimal_places=4,
-        help_text=_("The quantity at this very time."),
+        help_text=_("The quantity at this very time.<br/><br/>"),
     )
     comment = models.TextField(
         _("Comment"),
         blank=True,
         null=True,
         max_length=200,
-        help_text=_("A short conclusion."),
+        help_text=_("A short conclusion.<br/><br/>"),
     )
     date = models.DateTimeField(
         _("Verfication Date"),
@@ -749,12 +750,12 @@ class VerifiedStock(models.Model):
         null=False,
         default=datetime.now,
         db_index=True,
-        help_text=_("The date the verifiedcation was created."),
+        help_text=_("The date the verifiedcation was created.<br/><br/>"),
     )
     created_by = models.ForeignKey(
         User,
         verbose_name=_("Created by"),
-        help_text=_("The user which verified the stock."),
+        help_text=_("The user which verified the stock.<br/><br/>"),
         on_delete=models.PROTECT,
     )
 
@@ -768,12 +769,12 @@ class Transaction(models.Model):
     subject = models.CharField(
         _("Subject"),
         max_length=100,
-        help_text=_("A short conclusion of the transaction."),
+        help_text=_("A short conclusion of the transaction.<br/><br/>"),
     )
     storage_item = models.ForeignKey(
         StorageItem,
         help_text=_(
-            "The part-storage relation the transaction was applied on."
+            "The part-storage relation the transaction was applied on.<br/><br/>"
         ),
         on_delete=models.PROTECT,
     )
@@ -781,14 +782,14 @@ class Transaction(models.Model):
         _("Amount"),
         max_digits=10,
         decimal_places=4,
-        help_text=_("The quantity transferred."),
+        help_text=_("The quantity transferred.<br/><br/>"),
     )
     comment = models.TextField(
         _("Comment"),
         blank=True,
         null=True,
         max_length=200,
-        help_text=_("Optional: A short conclusion."),
+        help_text=_("Optional: A short conclusion.<br/><br/>"),
     )
 
     date = models.DateTimeField(
@@ -797,7 +798,7 @@ class Transaction(models.Model):
         null=False,
         default=datetime.now,
         db_index=True,
-        help_text=_("The date the transaction took part."),
+        help_text=_("The date the transaction took part.<br/><br/>"),
     )
     state = models.CharField(
         _("State"),
@@ -805,12 +806,12 @@ class Transaction(models.Model):
         choices=STATE_CHOICES,
         blank=True,
         default="---",
-        help_text=_("The status a transaction is in."),
+        help_text=_("The status a transaction is in.<br/><br/>"),
     )
     created_by = models.ForeignKey(
         User,
         verbose_name=_("Created by"),
-        help_text=_("The user which created the transaction."),
+        help_text=_("The user which created the transaction.<br/><br/>"),
         on_delete=models.PROTECT,
     )
     created_date = models.TimeField(
@@ -819,7 +820,7 @@ class Transaction(models.Model):
         null=False,
         auto_now_add=True,
         db_index=True,
-        help_text=_("The timestamp transaction has been entered."),
+        help_text=_("The timestamp transaction has been entered.<br/><br/>"),
     )
 
     reverted = models.BooleanField(
@@ -827,7 +828,7 @@ class Transaction(models.Model):
         default=False,
         help_text=_(
             "To control whether transaction has been already "
-            "reverted and cannot be reverted again."
+            "reverted and cannot be reverted again.<br/><br/>"
         ),
     )
 

--- a/partuniverse/templates/pmgmt/storage/bulkadd.html
+++ b/partuniverse/templates/pmgmt/storage/bulkadd.html
@@ -8,7 +8,7 @@
 
 
 {% block content %}
-<p>{% trans "Bulk add multiple storage places as a rectangle given in rows and columns resulting in places like A1 or B22" %}</p>
+<p>{% trans "Bulk add multiple storage places as a rectangle given in rows and columns resulting in places like A1 or B22." %}</p>
 <form method="post" class="ui form segment">
   {% csrf_token %}
   {{ form }}

--- a/partuniverse/templates/pmgmt/storageitem/add.html
+++ b/partuniverse/templates/pmgmt/storageitem/add.html
@@ -12,8 +12,7 @@
 {% block heading %}{% trans "Add a storage item" %}{% endblock %}
 
 {% block content %}
-<p>{% trans "Use this to add a new storage items, which is a combination
-    of a part a decent storage place. Actually: Where can I find this particular part." %}</p>
+<p>{% trans "Use this to add a new storage items, which is a combination of a part a decent storage place. Actually: Where can I find this particular part." %}</p>
 <form method="post" class="ui form" >
   {% csrf_token %}
   {{ form }}

--- a/partuniverse/templates/pmgmt/storageitem/stocktaking.html
+++ b/partuniverse/templates/pmgmt/storageitem/stocktaking.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <h1>{{ object }}</h1>
-<p>{% trans "It will create an Transaction adjusting the amount for items on stock to reported one.." %}</p>
+<p>{% trans "It will create an Transaction adjusting the amount for items on stock to reported one." %}</p>
 <form method="post" class="ui form segment">
   {% csrf_token %}
   {{ form }}


### PR DESCRIPTION
I have added newlines to the help texts, for a better readability. This fixes https://github.com/frlan/partuniverse/issues/275
I also found some typos, mainly full stops.