### PR TITLE
Replaced +- buttons in transaction with a single submit button

### DIFF
--- a/partuniverse/locale/de/LC_MESSAGES/django.po
+++ b/partuniverse/locale/de/LC_MESSAGES/django.po
@@ -76,10 +76,6 @@ msgstr "Unterschied"
 msgid "The amount of items taken/put to storage."
 msgstr "Die Menge die ein- bzw. ausgelagert wurde."
 
-#: partsmanagement/forms.py:44
-msgid "The amount of items taken/put to storage. Positiv values only."
-msgstr "Die Menge die ein- bzw. ausgelagert wurde. Nur positive Werte."
-
 #: partsmanagement/forms.py:52 partsmanagement/models.py:82
 #: templates/pmgmt/storage/detail.html:31
 msgid "Storage Type"

--- a/partuniverse/partsmanagement/forms.py
+++ b/partuniverse/partsmanagement/forms.py
@@ -37,9 +37,8 @@ class StorageItemAddTransactionForm(forms.Form):
         label=_("Difference"),
         max_digits=10,
         decimal_places=4,
-        min_value=0.0001,
         help_text=_(
-            "The amount of items taken/put to storage. " "Positiv values only."
+            "The amount of items taken/put to storage."
         ),
     )
 

--- a/partuniverse/partsmanagement/views.py
+++ b/partuniverse/partsmanagement/views.py
@@ -535,19 +535,11 @@ class StorageItemTransactionAddView(FormView):
         return context
 
     def form_valid(self, form):
-        if self.request.POST["submit"] == "+":
+        if self.request.POST["submit"] == "Submit":
             Transaction.objects.create(
                 subject=form.cleaned_data["description"],
                 created_by=self.request.user,
                 amount=form.cleaned_data["amount"],
-                storage_item=StorageItem.objects.get(pk=self.kwargs["pk"]),
-                date=timezone.now(),
-            )
-        elif self.request.POST["submit"] == "-":
-            Transaction.objects.create(
-                subject=form.cleaned_data["description"],
-                created_by=self.request.user,
-                amount=form.cleaned_data["amount"] * -1,
                 storage_item=StorageItem.objects.get(pk=self.kwargs["pk"]),
                 date=timezone.now(),
             )

--- a/partuniverse/templates/pmgmt/transaction/add.html
+++ b/partuniverse/templates/pmgmt/transaction/add.html
@@ -16,8 +16,7 @@
 <form method="post" class="ui form segment">
     {% csrf_token %}
     {{ form }}
-    <input class="ui button red" type="submit" name="submit" value="-">
-    <input class="ui button green" type="submit" name="submit" value="+">
+    <input class="ui button blue" type="submit" name="submit" value="{% trans "Submit" %}">
 </form>
 
 {% endblock %}


### PR DESCRIPTION
I replaced the +- buttons in the transaction form with a single submit button and allow positive and negative numbers. + and - had the same effect before.